### PR TITLE
fix: invalid compressed file for huge file

### DIFF
--- a/pdbstore/io/file.py
+++ b/pdbstore/io/file.py
@@ -287,3 +287,18 @@ def build_files_list(
             files_list.append(Path(file))
 
     return files_list
+
+
+def get_file_size(path: PathLike) -> int:
+    """Get file size
+
+    :param path: The file path
+    :return: The file size
+    """
+    if not path:
+        return 0
+    file_path: Path = util.str_to_path(path)
+    if not file_path or not file_path.exists():
+        return 0
+
+    return file_path.stat().st_size

--- a/pdbstore/store/entry.py
+++ b/pdbstore/store/entry.py
@@ -103,6 +103,16 @@ class TransactionEntry:
             dest_dir.mkdir(parents=True)
 
         if self.compressed:
+            # Sanity check to limit compression for file having size with less than 2GB
+            # 2GB is the limit of cab files as Microsoft documentation
+            max_cab_file_size = 2147483648
+            if max_cab_file_size < self.source_file.stat().st_size:
+                self.compressed = False
+                PDBStoreOutput().warning(
+                    f"Disable compression for {self.source_file} since file size is more than 2GB"
+                )
+
+        if self.compressed:
             PDBStoreOutput().debug(
                 f"Compressing {self.source_file} to {str(dest_dir / (self.file_name[:-1] + '_'))}"
             )

--- a/pdbstore/store/entry.py
+++ b/pdbstore/store/entry.py
@@ -12,6 +12,9 @@ __all__ = ["TransactionEntry"]
 class TransactionEntry:
     """A SymbolStore transaction entry representation"""
 
+    # File size limit to disable compression
+    MAX_COMPRESSED_FILE_SIZE: int = 2147482624
+
     def __init__(
         self,
         store: "Store",  # type: ignore[name-defined] # noqa: F821
@@ -104,9 +107,8 @@ class TransactionEntry:
 
         if self.compressed:
             # Sanity check to limit compression for file having size with less than 2GB
-            # 2GB is the limit of cab files as Microsoft documentation
-            max_cab_file_size = 2147483648
-            if max_cab_file_size < self.source_file.stat().st_size:
+            # 2GB is the limit of cab files as per Microsoft documentation
+            if self.MAX_COMPRESSED_FILE_SIZE < io.file.get_file_size(self.source_file):
                 self.compressed = False
                 PDBStoreOutput().warning(
                     f"Disable compression for {self.source_file} since file size is more than 2GB"

--- a/tests/unit/test_transaction_entry.py
+++ b/tests/unit/test_transaction_entry.py
@@ -185,3 +185,19 @@ def test_extract_failure(tmp_path, tmp_store, test_data_native_dir, fake_process
         entry.compressed = False
         with pytest.raises(exceptions.CopyFileError):
             entry.extract(tmp_path)
+
+
+def test_large_compressed_file(tmp_store, test_data_native_dir):
+    """test no compress for very large file"""
+    with mock.patch("pdbstore.io.file.get_file_size") as _get_file_size:
+        _get_file_size.return_value = TransactionEntry.MAX_COMPRESSED_FILE_SIZE + 10
+        entry = TransactionEntry(
+            tmp_store,
+            "dummylib.pdb",
+            "1972BE39B97341928816018A8ECD08D91",
+            test_data_native_dir / "dummylib.pdb",
+            True,
+        )
+        assert entry.commit() is True
+        assert entry.is_compressed() is False
+        assert entry.stored_path.exists()


### PR DESCRIPTION
as reported by client, pdbstore is generating incomplete compressed file based on `makecab.exe` utility.

Reference: https://techcommunity.microsoft.com/t5/windows-server-for-developers/makecab-command-has-limitation-of-2gb-package-size/m-p/1599480