### PR TITLE
feat: commit files in parallel

### DIFF
--- a/pdbstore/store/transaction.py
+++ b/pdbstore/store/transaction.py
@@ -359,9 +359,6 @@ class Transaction:
                 add_res.group("comment"),
             )
 
-        if transaction_type != TransactionType.DEL.value:
-            return None
-
         del_res = TransactionRegEx.TRANSACTION_DEL_RE.match(line_res.group("tail"))
         if not del_res:
             PDBStoreOutput().debug(

--- a/pdbstore/store/transaction.py
+++ b/pdbstore/store/transaction.py
@@ -232,7 +232,7 @@ class Transaction:
 
         if self.is_committed():
             PDBStoreOutput().warning(
-                "Transction ID {self.transaction_id} is already committed, so ignore it",
+                f"Transction ID {self.transaction_id} is already committed, so ignore it",
             )
             summary.status = OpStatus.SKIPPED
             return summary

--- a/pdbstore/store/transaction.py
+++ b/pdbstore/store/transaction.py
@@ -1,5 +1,6 @@
 """ Manage a single transaction.
 """
+import concurrent.futures as cf
 import os
 import re
 from datetime import datetime
@@ -16,7 +17,7 @@ from pdbstore.io.output import PDBStoreOutput
 from pdbstore.store.entry import TransactionEntry
 from pdbstore.store.summary import OpStatus, Summary
 from pdbstore.store.transaction_type import TransactionType
-from pdbstore.typing import List, Optional, PathLike, Union
+from pdbstore.typing import List, Optional, PathLike, Tuple, Union
 
 __all__ = ["Transaction"]
 
@@ -200,6 +201,18 @@ class Transaction:
         # Not found
         return None
 
+    @staticmethod
+    def __commit_entry(
+        entry: TransactionEntry, force: Optional[bool] = False
+    ) -> Tuple[TransactionEntry, Union[OpStatus, PDBStoreException]]:
+        try:
+            return (
+                entry,
+                OpStatus.SUCCESS if entry.commit(force) else OpStatus.SKIPPED,
+            )
+        except PDBStoreException as exc:  # pragma: no cover
+            return (entry, exc)
+
     def commit(
         self,
         transaction_id: str,
@@ -234,22 +247,24 @@ class Transaction:
         self.transaction_id = transaction_id
 
         # publish all entries files to the store
-        for entry in self.entries:
-            try:
-                status = OpStatus.SUCCESS if entry.commit(force) else OpStatus.SKIPPED
-                summary.add_entry(
-                    entry,
-                    status,
-                    TransactionType.ADD,
-                )
-            except PDBStoreException as exc:  # pragma: no cover
-                summary.status = OpStatus.FAILED
-                summary.add_entry(
-                    entry,
-                    OpStatus.FAILED,
-                    TransactionType.ADD,
-                )
-                PDBStoreOutput().error(exc)
+        with cf.ThreadPoolExecutor() as executor:
+            for result in executor.map(
+                lambda entry: Transaction.__commit_entry(entry, force), self.entries
+            ):
+                if isinstance(result[1], OpStatus):
+                    summary.add_entry(
+                        result[0],
+                        result[1],
+                        TransactionType.ADD,
+                    )
+                else:
+                    summary.status = OpStatus.FAILED
+                    summary.add_entry(
+                        result[0],
+                        OpStatus.FAILED,
+                        TransactionType.ADD,
+                    )
+                    PDBStoreOutput().error(result[1])
 
         # write new transaction file
         try:

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -153,3 +153,24 @@ def test_parallel_commit(tmp_store, test_data_native_dir):
     assert len(files) == 2
     assert files[0]["status"] == OpStatus.FAILED.value
     assert files[1]["status"] == OpStatus.SUCCESS.value
+    assert transaction.compute_disk_usage() > 0
+    assert transaction.find_entry("", "") is None
+    assert (
+        transaction.find_entry("dummyapp.pdb", "DBF7CE25C6DC4E0EA9AD889187E296A21")
+        is not None
+    )
+    assert transaction.find_entry("dummyapp.pdb", "") is None
+
+
+def test_parse_line(tmp_store):
+    """Test parse_line behavior"""
+    assert (
+        Transaction.parse_line(
+            tmp_store, '0000000001,add,file,11/05/2023,14:46:44,"None","None","None",'
+        )
+        is not None
+    )
+    assert Transaction.parse_line(tmp_store, "0000000001,add,") is None
+    assert Transaction.parse_line(tmp_store, "0000000002,del,0000000001") is not None
+    assert Transaction.parse_line(tmp_store, "0000000002,del,") is None
+    assert Transaction.parse_line(tmp_store, "0000000002,delc,0000000001") is None


### PR DESCRIPTION
Parallelize the commit transaction entries in order to improve performance

Since **ThreadPoolExecutor** is used, the maximum number of parallel executors will be based on the number of cores/processors